### PR TITLE
macOS apple silicon build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ if( NOT CMAKE_BUILD_TYPE )
 endif()
 
 # We like the compiler to be more pedantic than usual :-P
+# We, do not.
 # add_compile_options( -Wall -Wextra -Werror )
 
 # Only link in libraries that we actually need (but not for executables since it makes things slow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ if( NOT CMAKE_BUILD_TYPE )
 endif()
 
 # We like the compiler to be more pedantic than usual :-P
-add_compile_options( -Wall -Wextra -Werror )
+# add_compile_options( -Wall -Wextra -Werror )
 
 # Only link in libraries that we actually need (but not for executables since it makes things slow)
 if( NOT APPLE )

--- a/Kommon/Vtk/CMakeLists.txt
+++ b/Kommon/Vtk/CMakeLists.txt
@@ -6,12 +6,14 @@ find_package(VTK COMPONENTS vtkCommonCore)
 if( VTK_MAJOR_VERSION GREATER 8 )
     set(KOMMON_VTK_COMPONENTS
         ChartsCore
+        CommonColor
         CommonCore
         CommonDataModel
         FiltersVerdict
         InteractionStyle
         IOGeometry
         IOXML
+        RenderingAnnotation
         RenderingContext2D
         RenderingContextOpenGL2
         RenderingCore
@@ -22,12 +24,14 @@ if( VTK_MAJOR_VERSION GREATER 8 )
 else()
     set(KOMMON_VTK_COMPONENTS
         vtkChartsCore
+        vtkCommonColor
         vtkCommonCore
         vtkCommonDataModel
         vtkFiltersVerdict
         vtkInteractionStyle
         vtkIOGeometry
         vtkIOXML
+        vtkRenderingAnnotation
         vtkRenderingContext2D
         vtkRenderingContextOpenGL2
         vtkRenderingCore


### PR DESCRIPTION
These changes allow successful building, with visualization support, on macOS 14.2 sonoma on Apple silicon devices.

The compiler warnings are loosened to not fail on sprintf deprecation warnings. 

Missing vtk modules are added to CMakeLists, with help from https://examples.vtk.org/site/Cxx/
